### PR TITLE
Security fixes for issues with immutability and secrets

### DIFF
--- a/src/main/java/com/salesforce/cdp/queryservice/util/Constants.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/Constants.java
@@ -82,7 +82,14 @@ public class Constants {
     public static final String CLIENT_SECRET_NAME = "client_secret";
     public static final String CLIENT_USER_NAME = "username";
     public static final String CLIENT_PD = "password";
+    public static final String TOKEN_SEPARATOR = "&";
+    public static final String TOKEN_ASSIGNMENT = "=";
 
     // Header Constants
     public static final String TRACE_ID = "x-trace-id";
+
+
 }
+
+
+

--- a/src/main/java/com/salesforce/cdp/queryservice/util/HttpHelper.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/HttpHelper.java
@@ -33,20 +33,29 @@ import java.util.Map;
 public class HttpHelper {
 
     public static void handleErrorResponse(Response response, String propertyName) throws IOException, SQLException {
-        ObjectNode node = new ObjectMapper().readValue(response.body().string(), ObjectNode.class);
+        handleErrorResponse(response.body().string(), propertyName);
+    }
+
+    public static void handleErrorResponse(String response, String propertyName) throws IOException, SQLException {
+        ObjectNode node = new ObjectMapper().readValue(response, ObjectNode.class);
         JsonNode jsonNode = node.get(propertyName);
         String message = jsonNode == null ? String.format("Property %s is not defined", propertyName) : node.get(propertyName).asText();
         throw new SQLException(message);
     }
 
-    public static <T> T handleSuccessResponse(Response response, Class<T> type, boolean cacheResponse) throws IOException {
-        String responseString = response.body().string();
-        if (response.headers().get("from-local-cache") == null && cacheResponse) {
-            log.info("Caching the response");
-            MetadataCacheUtil.cacheMetadata(response.request().url().toString(), responseString);
-        }
+    public static <T> T handleSuccessResponse(String responseString, Class<T> type) throws IOException {
+
         ObjectMapper mapper = new ObjectMapper();
         return mapper.readValue(responseString, type);
+    }
+
+    public static <T> T handleSuccessResponse(Response response, Class<T> type, boolean cacheResponse) throws IOException {
+        if (response.headers().get("from-local-cache") == null && cacheResponse) {
+            log.info("Caching the response");
+            MetadataCacheUtil.cacheMetadata(response.request().url().toString(), response.body().string());
+        }
+
+        return handleSuccessResponse(response.body().string(), type);
     }
 
     protected static Request buildRequest(String method, String url, RequestBody body, Map<String, String> headers) {

--- a/src/main/java/com/salesforce/cdp/queryservice/util/TokenHelper.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/TokenHelper.java
@@ -201,12 +201,12 @@ public class TokenHelper {
 
     private static String un_pw_login(String grantType, String clientId, byte[] clientSecret, String userName, byte[] passwordBytes, String tokenUrl) throws Exception
     {
-        byte[] grantTypeSegment = ("grant_type=" + grantType).getBytes("utf-8");
-        byte[] clientIdSegment = ("client_id=" + clientId).getBytes("utf-8");
-        byte[] clientSecretSegment = "client_secret=".getBytes("utf-8");
-        byte[] userNameSegment = ("username=" + URLEncoder.encode(userName)).getBytes("utf-8");
-        byte[] passwordSegment = ("password=").getBytes("utf-8");
-        byte[] separator = "&".getBytes("utf-8");
+        byte[] grantTypeSegment = (Constants.GRANT_TYPE_NAME + Constants.TOKEN_ASSIGNMENT + grantType).getBytes("utf-8");
+        byte[] clientIdSegment = (Constants.CLIENT_ID_NAME + Constants.TOKEN_ASSIGNMENT + clientId).getBytes("utf-8");
+        byte[] clientSecretSegment = (Constants.CLIENT_SECRET_NAME + Constants.TOKEN_ASSIGNMENT).getBytes("utf-8");
+        byte[] userNameSegment = (Constants.CLIENT_USER_NAME + Constants.TOKEN_ASSIGNMENT + URLEncoder.encode(userName)).getBytes("utf-8");
+        byte[] passwordSegment = (Constants.CLIENT_PD + Constants.TOKEN_ASSIGNMENT).getBytes("utf-8");
+        byte[] separator = Constants.TOKEN_SEPARATOR.getBytes("utf-8");
 
 
         // Pre-calculate the size of the postdata in bytes we'll be sending for Content-Length.

--- a/src/main/java/com/salesforce/cdp/queryservice/util/TokenHelper.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/TokenHelper.java
@@ -28,7 +28,10 @@ import okhttp3.Request;
 import okhttp3.Response;
 import org.apache.commons.lang3.StringUtils;
 
-import java.io.IOException;
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
 import java.sql.SQLException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
@@ -75,23 +78,50 @@ public class TokenHelper {
     }
 
     private static Map<String, String> retrieveTokenWithPasswordGrant(Properties properties, OkHttpClient client) throws SQLException {
-        // Convert password to byte array as per SA
+        // Check for password and client secret.
         if (properties.getProperty(Constants.PD) == null) {
             throw new SQLException("Password cannot be null");
         }
-        byte [] passwordBytes = properties.getProperty(Constants.PD).getBytes();
-        properties.put(Constants.PD, passwordBytes);
+
+        if (properties.getProperty(Constants.CLIENT_SECRET) == null) {
+            throw new SQLException("Client Secret cannot be null");
+        }
+
         String token_url = properties.getProperty(Constants.LOGIN_URL) + Constants.CORE_TOKEN_URL;
-        Map<String, String> requestBody = new HashMap<>();
-        requestBody.put(Constants.GRANT_TYPE_NAME, Constants.TOKEN_GRANT_TYPE_PD);
-        requestBody.put(Constants.CLIENT_ID_NAME, properties.getProperty(Constants.CLIENT_ID));
-        requestBody.put(Constants.CLIENT_SECRET_NAME, properties.getProperty(Constants.CLIENT_SECRET));
-        requestBody.put(Constants.CLIENT_USER_NAME, properties.getProperty(Constants.USER_NAME));
-        requestBody.put(Constants.CLIENT_PD, new String(passwordBytes));
         CoreTokenRenewResponse coreTokenRenewResponse = null;
+        byte[] passwordBytes = null;
+        byte[] clientSecret = null;
+
+
+        // Convert the password and client secret to byte arrays so we can empty them at will.
         try {
-            Response response = login(requestBody, token_url, client);
-            coreTokenRenewResponse = HttpHelper.handleSuccessResponse(response, CoreTokenRenewResponse.class, false);
+            passwordBytes = Utils.safeByteArrayUrlEncode(Utils.asByteArray(properties.getProperty(Constants.PD)));
+            clientSecret = Utils.asByteArray(properties.getProperty(Constants.CLIENT_SECRET));
+
+
+            // Remove the properties from the propertybag so that GC can collect them ASAP.
+            properties.remove(Constants.PD);
+            properties.remove(Constants.CLIENT_SECRET);
+
+
+            // And handle the initial login *without* immutables. This ensures that nothing
+            // is allocated in memory that cannot be cleared on demand and thus we aren't
+            // at the garbage collectors mercy.
+            String response = un_pw_login(Constants.TOKEN_GRANT_TYPE_PD,
+                                          properties.getProperty(Constants.CLIENT_ID),
+                                          clientSecret,
+                                          properties.getProperty(Constants.USER_NAME),
+                                          passwordBytes,
+                                          token_url);
+
+
+            // Then get rid of the secrets from memory
+            Arrays.fill(passwordBytes, (byte)0);
+            Arrays.fill(clientSecret, (byte)0);
+
+
+            // And exchange the UN/PW flow authtoken for a scoped bearer token.
+            coreTokenRenewResponse = HttpHelper.handleSuccessResponse(response, CoreTokenRenewResponse.class);
             Token token = exchangeToken(properties.getProperty(Constants.LOGIN_URL), coreTokenRenewResponse.getAccess_token(), client);
             tokenCache.put(properties.getProperty(Constants.USER_NAME), token);
             return getTokenWithUrl(token);
@@ -101,6 +131,7 @@ public class TokenHelper {
             throw new SQLException(TOKEN_EXCHANGE_FAILURE);
         } finally {
             Arrays.fill(passwordBytes, (byte)0);
+            Arrays.fill(clientSecret, (byte)0);
         }
     }
 
@@ -167,6 +198,76 @@ public class TokenHelper {
     private static void clearToken(String tokenKey) {
         tokenCache.invalidate(tokenKey);
     }
+
+    private static String un_pw_login(String grantType, String clientId, byte[] clientSecret, String userName, byte[] passwordBytes, String tokenUrl) throws Exception
+    {
+        byte[] grantTypeSegment = ("grant_type=" + grantType).getBytes("utf-8");
+        byte[] clientIdSegment = ("client_id=" + clientId).getBytes("utf-8");
+        byte[] clientSecretSegment = "client_secret=".getBytes("utf-8");
+        byte[] userNameSegment = ("username=" + URLEncoder.encode(userName)).getBytes("utf-8");
+        byte[] passwordSegment = ("password=").getBytes("utf-8");
+        byte[] separator = "&".getBytes("utf-8");
+
+
+        // Pre-calculate the size of the postdata in bytes we'll be sending for Content-Length.
+        int postDataLength = grantTypeSegment.length +
+                             separator.length +
+                             clientIdSegment.length +
+                             separator.length +
+                             clientSecretSegment.length +
+                             clientSecret.length +
+                             separator.length +
+                             userNameSegment.length +
+                             separator.length +
+                             passwordSegment.length +
+                             passwordBytes.length;
+
+
+        // Setup the connection parameters and write out the POST body
+        HttpURLConnection connection = (HttpURLConnection)(new URL(tokenUrl).openConnection());
+        connection.setDoOutput(true);
+        connection.setRequestMethod("POST");
+        connection.setRequestProperty("User-Agent", "cdp/jdbc");
+        connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+        connection.setRequestProperty("Content-Length", Integer.toString(postDataLength));
+        connection.setRequestProperty("Connection", "Keep-Alive");
+        connection.setUseCaches(false);
+
+        OutputStream os = connection.getOutputStream();
+        os.write(grantTypeSegment);
+        os.write(separator);
+        os.write(clientIdSegment);
+        os.write(separator);
+        os.write(clientSecretSegment);
+        os.write(clientSecret);
+        os.write(separator);
+        os.write(userNameSegment);
+        os.write(separator);
+        os.write(passwordSegment);
+        os.write(passwordBytes);
+        os.flush();
+
+
+        // Read back the response body.
+        BufferedReader br = new BufferedReader(new InputStreamReader((connection.getInputStream())));
+        StringBuilder sb = new StringBuilder();
+        String output;
+        while ((output = br.readLine()) != null) {
+            sb.append(output);
+        }
+
+        String message = sb.toString();
+
+        // And return the message we got or error it.
+        if (connection.getResponseCode() != 200) {
+            log.error("Token exchange failed with status code {}", connection.getResponseCode());
+            HttpHelper.handleErrorResponse(message, Constants.ERROR_DESCRIPTION);
+        }
+
+
+        return message;
+    }
+
 
     private static Response login(Map<String, String> requestBody, String url, OkHttpClient client) throws IOException, SQLException {
         FormBody.Builder formBody = new FormBody.Builder();

--- a/src/main/java/com/salesforce/cdp/queryservice/util/Utils.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/Utils.java
@@ -18,6 +18,7 @@ package com.salesforce.cdp.queryservice.util;
 
 import com.salesforce.cdp.queryservice.interfaces.ExtendedHttpStatusCode;
 
+import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -36,5 +37,87 @@ public class Utils {
     public static Set<Integer> getRetryStatusCodes() {
         return retryStatusCodes;
     }
+
+
+    public static byte[] safeByteArrayUrlEncode(byte[] byteArray) {
+        int bytesNeedingReEncode = 0;
+
+        // As per the URLEncode.encode() documentation we implement the byte array version here
+        // (to keep us from forming immutable strings)
+        // The alphanumeric characters "a" through "z", "A" through "Z" and "0" through "9" remain the same.
+        // The special characters ".", "-", "*", and "_" remain the same.
+        // The space character " " is converted into a plus sign "+".
+        // All other characters are unsafe and are first converted into one or more bytes using some encoding scheme. Then each byte is represented by the 3-character string "%xy", where xy is the two-digit hexadecimal representation of the byte. The recommended encoding scheme to use is UTF-8. However, for compatibility reasons, if an encoding is not specified, then the default encoding of the platform is used.
+
+
+        // First calculate all the bytes needing re-encode (these will require 3 characters per instead of one in the
+        // new array)
+        for (int i = 0; i < byteArray.length; i++) {
+            if (!Character.isAlphabetic(byteArray[i]) &&
+                    !Character.isDigit(byteArray[i]) &&
+                    byteArray[i] != '.' &&
+                    byteArray[i] != '-' &&
+                    byteArray[i] != '*' &&
+                    byteArray[i] != '_' &&
+                    byteArray[i] != ' ') bytesNeedingReEncode++;
+        }
+
+
+        // Now allocate the new byte array to accomodate for the values, each encoded byte is 3 bytes now, but we already
+        // have one byte of the three for the original bytes, so we only need to allocate origlength + bytesNeedingReEncode * 2
+        byte [] encoded = new byte[byteArray.length + (bytesNeedingReEncode * 2)];
+
+        int j = 0;
+        for (int i = 0; i < byteArray.length; i++)
+        {
+            if (Character.isAlphabetic(byteArray[i]) ||
+                    Character.isDigit(byteArray[i]) ||
+                    byteArray[i] == '.' ||
+                    byteArray[i] == '-' ||
+                    byteArray[i] == '*' ||
+                    byteArray[i] == '_') {
+
+                encoded[j++] = byteArray[i];
+            } else if (byteArray[i] == ' ') {
+                encoded[j++] = '+';
+            } else {
+                encoded[j++] = '%';
+                encoded[j++] = toHexDigit((byte)((byteArray[i] & 0xf0) >> 4));
+                encoded[j++] = toHexDigit((byte)(byteArray[i] & 0x0f));
+            }
+
+            byteArray[i] = 0;
+        }
+
+        return encoded;
+    }
+
+    private static byte toHexDigit(byte b) {
+        if (b > 9) {
+            return (byte)('a' + (b - 10));
+        } else {
+            return (byte)('0' + b);
+        }
+    }
+
+
+
+
+    public static byte[] asByteArray(Object property) throws UnsupportedEncodingException, IllegalArgumentException {
+        if (property instanceof byte[])
+        {
+            return (byte[])property;
+        }
+        else
+        {
+            if (property instanceof String)
+            {
+                return ((String) property).getBytes("utf-8");
+            }
+        }
+
+        throw new IllegalArgumentException(property.getClass().getName() + " is not a valid type for asByteArray()");
+    }
+
 
 }

--- a/src/main/java/com/salesforce/cdp/queryservice/util/Utils.java
+++ b/src/main/java/com/salesforce/cdp/queryservice/util/Utils.java
@@ -108,12 +108,9 @@ public class Utils {
         {
             return (byte[])property;
         }
-        else
+        else if (property instanceof String)
         {
-            if (property instanceof String)
-            {
-                return ((String) property).getBytes("utf-8");
-            }
+            return ((String) property).getBytes("utf-8");
         }
 
         throw new IllegalArgumentException(property.getClass().getName() + " is not a valid type for asByteArray()");


### PR DESCRIPTION
These are the fixes for immutability of clientsecret and password.

It drops the reference to the strings immediately upon request for login converting them to byte arrays and treating all the content as byte arrays for the UN/PW flow until it's completed. It then proceeds to erase the data within those arrays to ensure that the secrets are no longer in memory before the byte arrays themselves can be reaped by garbage collection.

The property bag sent to the JDBC driver also could take a byte array for client secret and for password obviating the need for passing strings in any case. The end result would be the same and the byte arrays would be cleared upon use as well. (The library method supports both natively, without any code change for the user).